### PR TITLE
Bugfix for call_indirect with imported functions (and test case).

### DIFF
--- a/lib/wasm/wasm_module.ml
+++ b/lib/wasm/wasm_module.ml
@@ -58,9 +58,15 @@ let get_type (m : t) (tid : Int32.t) : Type.t list * Type.t list =
 
 (** Get the type of the function with index fidx *)
 let get_func_type (m : t) (fidx : Int32.t) : Type.t list * Type.t list =
-  match List32.nth m.funcs Int32.(fidx-m.nfuncimports) with
-  | Some v -> v.typ
-  | None -> failwith "get_func_type nth exception"
+  (* match List32.nth m.funcs Int32.(fidx-m.nfuncimports) with *)
+  if Int32.(fidx >= m.nfuncimports) then
+      match List32.nth m.funcs Int32.(fidx-m.nfuncimports) with
+      | Some v -> v.typ
+      | None -> failwith "get_func_type nth exception"
+  else
+    match List32.nth m.imported_funcs fidx with
+      | Some v -> let (_,_,t)=v in t
+      | None -> failwith "get_func_type nth exception"
 
 (** Remove a function from the module *)
 let remove_func (m : t) (fidx : Int32.t) : t =

--- a/test/call_indirect-with_imported_element.wat
+++ b/test/call_indirect-with_imported_element.wat
@@ -10,5 +10,5 @@
   (elem (i32.const 0) $bar1 $f1 $callBar1)
   (func $callBar1 (export "callBar1")
     i32.const 0
-    call_indirect (type 0))
+    call_indirect )
 )

--- a/test/call_indirect-with_imported_element.wat
+++ b/test/call_indirect-with_imported_element.wat
@@ -1,0 +1,14 @@
+(module
+  (type (;0;) (func (result i32)))
+  (type (;1;) (func (param i32) (result i32)))
+  (import "foo" "bar1" (func $bar1 (type 0)))
+  (import "foo" "bar2" (func $bar2 (type 0)))
+  (import "foo" "bar3" (func $bar3 (type 1)))
+  (table 3 funcref)
+  (func $f1 (type 0) (result i32)
+    i32.const 42)
+  (elem (i32.const 0) $bar1 $f1 $callBar1)
+  (func $callBar1 (export "callBar1")
+    i32.const 0
+    call_indirect (type 0))
+)


### PR DESCRIPTION
Hi, 
I think this is a bug, please find attached the test which on the current upstream version causes a crash in the generation of the callgraph.
With my proposed change it doens't fail.

Cheers.
M.