### PR TITLE
Check validity of modules upon load

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,5 +29,5 @@ jobs:
         run: make
       - name: Compile web version
         run: |
+          opam install js_of_ocaml js_of_ocaml-ppx
           make js
-          cp ./

--- a/lib/analysis/sizes/sizes.ml
+++ b/lib/analysis/sizes/sizes.ml
@@ -138,8 +138,9 @@ let generate_binary (m : Wasm_module.t) (filename : string option) : t =
 
     let block_type = function
       (* TODO: VarBlockType x -> vs33 x.it *)
-      | None -> vs7 (-0x40)
-      | Some t -> value_type t
+      | [], [] -> vs7 (-0x40)
+      | [], [t] -> value_type t
+      | _ -> failwith "unsupported: sizes with other block type"
 
     let rec instr (e : unit Instr.t) = match e with
       | Data i -> begin match i.instr with

--- a/lib/analysis/slice/control_deps.ml
+++ b/lib/analysis/slice/control_deps.ml
@@ -200,7 +200,6 @@ let annotate_exact (cfg : Spec.t Cfg.t) : string =
                  (Printf.sprintf "block%d -> block%d [color=green]" a b) :: acc)))
 
 let%test "control dependencies computation" =
-  (* TODO: this one fails because br_if clears the stack as the block has no result, but there was one value on the stack before *)
   let open Instr.Label.Test in
   let module_ = Wasm_module.of_string "(module
   (type (;0;) (func (param i32) (result i32)))
@@ -220,7 +219,7 @@ let%test "control dependencies computation" =
       drop
     end
     memory.size)
-  )" in
+  (memory (;0;) 2))" in
   let cfg = Spec_analysis.analyze_intra1 module_ 0l in
   let actual = Var.Map.map (make cfg) ~f:(fun p -> Var.Set.of_list (List.map (Pred.Set.to_list p) ~f:fst)) in
   let var n = Var.Var n in
@@ -240,6 +239,7 @@ let%test "control deps with br_if" =
       drop        ;; Instr 4
     end
     local.get 0)   ;; Instr 5
+  (memory (;0;) 2)
   )" in
   let cfg = Spec_analysis.analyze_intra1 module_ 0l in
   let actual = make cfg in

--- a/lib/analysis/slice/memory_deps.ml
+++ b/lib/analysis/slice/memory_deps.ml
@@ -42,7 +42,7 @@ module Test = struct
     i32.store       ;; Instr 2
     memory.size     ;; Instr 3
     i32.load)       ;; Instr 4
-  )" in
+  (memory (;0;) 2))" in
     let cfg = Spec_analysis.analyze_intra1 module_ 0l in
     let deps = make cfg in
     let actual = deps_for deps (lab 4) in
@@ -51,16 +51,16 @@ module Test = struct
   let%test "mem-dep with call" =
     let open Instr.Label.Test in
     let module_ = Wasm_module.of_string "(module
-  (type (;0;) (func (param i32) (result i32)))
+  (type (;0;) (func (param i32) (result i32 i32 i32)))
   (type (;1;) (func))
-  (func (;test;) (type 0) (param i32) (result i32)
+  (func (;test;) (type 0) (param i32) (result i32 i32 i32)
     memory.size     ;; Instr 0
     memory.size     ;; Instr 1
     call 1       ;; Instr 2
     memory.size     ;; Instr 3
     i32.load)       ;; Instr 4
   (func (;1;) (type 1))
-  )" in
+  (memory (;0;) 2))" in
     let cfg = Spec_analysis.analyze_intra1 module_ 0l in
     let deps = make cfg in
     let actual = deps_for deps (lab 4) in

--- a/lib/analysis/slice/use_def.ml
+++ b/lib/analysis/slice/use_def.ml
@@ -182,7 +182,7 @@ module Test = struct
     i32.add     ;; Instr 2 [i2] defines i2, uses i0 and i1
                 ;; return block: defines ret, uses i2
     )
-  )" in
+   (memory (;0;) 2))" in
     let cfg = Spec_analysis.analyze_intra1 module_ 0l in
     let _, _, actual = make cfg in
     let expected = Use.Map.of_alist_exn [(Use.make (lab 2) (Var.Var (lab 0)), Def.Instruction (lab 0, (Var.Var (lab 0))));
@@ -222,8 +222,8 @@ module Test = struct
     ;; At this point we have a merge block, merging i2 and i3 into m4_1
     memory.size     ;; Instr 4
     i32.add)        ;; Instr 5
-    ;; Final merge block: i5 -> ret
-  )" in
+    ;; Final merge block: i5 -> ret
+   (memory (;0;) 2))" in
     let cfg = Spec_analysis.analyze_intra1 module_ 0l in
     let _, _, actual = make cfg in
     let expected = Use.Map.of_alist_exn [(Use.make (lab 1) (Var.Var (lab 0)), Def.Instruction (lab 0, Var.Var (lab 0)));
@@ -237,15 +237,15 @@ module Test = struct
   let%test "use-def with memory" =
     let open Instr.Label.Test in
     let module_ = Wasm_module.of_string "(module
-  (type (;0;) (func (param i32) (result i32)))
-  (func (;test;) (type 0) (param i32) (result i32)
+  (type (;0;) (func (param i32)))
+  (func (;test;) (type 0) (param i32)
     memory.size     ;; Instr 0, Var 0
     memory.size     ;; Instr 1, Var 1
     i32.store       ;; Instr 2, i0+0 mapped to i1 (no new var!)
     memory.size     ;; Instr 3, Var 3
     memory.size     ;; Instr 4, Var 4
     i32.store)       ;; Instr 5, i3+0 mapped to i4 (no new var!)
-  )" in
+   (memory (;0;) 2))" in
     let cfg = Spec_analysis.analyze_intra1 module_ 0l in
     let _, _, actual = make cfg in
     let expected = Use.Map.of_alist_exn [(Use.make (lab 2) (Var.Var (lab 0)), Def.Instruction (lab 0, Var.Var (lab 0)));
@@ -263,7 +263,7 @@ module Test = struct
     memory.grow ;; Instr 1, Var 1, uses var 0
     drop        ;; Instr 2, uses var 1
    )
-  )" in
+   (memory (;0;) 2))" in
     let cfg = Spec_analysis.analyze_intra1 module_ 0l in
     let _, _, actual = make cfg in
     let expected = Use.Map.of_alist_exn [(Use.make (lab 1) (Var.Var (lab 0)), Def.Instruction (lab 0, Var.Var (lab 0)));

--- a/lib/analysis/spec/spec_analysis.ml
+++ b/lib/analysis/spec/spec_analysis.ml
@@ -50,11 +50,11 @@ module Test = struct
   (type (;0;) (func))
   (import \"env\" \"DYNAMICTOP_PTR\" (global (;0;) i32))
   (func (;test;) (type 0)
-    global.get 1
-    global.set 0)
+    global.get 0
+    global.set 1)
   (table (;0;) 1 1 funcref)
   (memory (;0;) 2)
-  (global (;0;) (mut i32) (i32.const 66560)))"
+  (global (;1;) (mut i32) (i32.const 66560)))"
 
   let%test_unit "spec analysis succeeds with blocks" =
     does_not_fail "(module
@@ -139,7 +139,7 @@ module Test = struct
     else
       i32.const -10420289 ;; [_]
     end)
-)"
+  (memory (;0;) 2))"
 
 
 end

--- a/lib/cfg/codegen.ml
+++ b/lib/cfg/codegen.ml
@@ -30,8 +30,8 @@ module Test = struct
 
   let%test "codegen for trivial module should generate all the code" =
     output_exactly_matches_input "(module
-  (type (;0;) (func (param i32) (result i32)))
-  (func (;0;) (type 0) (param i32) (result i32)
+  (type (;0;) (func (param i32)))
+  (func (;0;) (type 0) (param i32)
     memory.size
     memory.size
     i32.store
@@ -47,7 +47,7 @@ module Test = struct
     output_exactly_matches_input "(module
   (type (;0;) (func (param i32) (result i32)))
   (func (;0;) (type 0) (param i32) (result i32)
-    block
+    block (result i32)
       i32.const 0
       drop
       block
@@ -71,7 +71,7 @@ module Test = struct
     i32.const -1
     i32.store offset=12
     i32.const 1812
-    i32.const -1
+    i64.const -1
     i64.store offset=8 align=4
     i32.const 1812
     i32.const -1
@@ -85,8 +85,8 @@ module Test = struct
 
   let%test "codegen for consecutive blocks should produce the same result" =
     output_exactly_matches_input "(module
-  (type (;0;) (func (param i32) (result i32)))
-  (func (;0;) (type 0) (param i32) (result i32)
+  (type (;0;) (func (param i32)))
+  (func (;0;) (type 0) (param i32)
     block
       loop
         i32.const 0
@@ -156,10 +156,11 @@ module Test = struct
   let%test "codegen should support if branches that jump to different places" =
     output_exactly_matches_input "(module
   (type (;0;) (func (param i32) (result i32)))
+  (type (;1;) (func (param i32)))
   (func (;0;) (type 0) (param i32) (result i32)
-    block
+    block (result i32)
       local.get 0
-      block
+      block (param i32)
         if
           br 0
         else

--- a/lib/cfg/lexical_successor_tree.ml
+++ b/lib/cfg/lexical_successor_tree.ml
@@ -88,9 +88,9 @@ module Test = struct
 
   let%test "lexical successor tree with blocks" =
     let t = make [data 1 (Instr.Const (Prim_value.of_int 0));
-                  control 2 (Instr.Block (None, (0, 0),
+                  control 2 (Instr.Block (([], []), (0, 0),
                                           [data 3 (Instr.Const (Prim_value.of_int 0));
-                                           control 4 (Instr.Block (None, (0, 0),
+                                           control 4 (Instr.Block (([], []), (0, 0),
                                                                    [control 5 (Instr.Br 0l)]))]));
                   data 6 (Instr.Const (Prim_value.of_int 0))] in
     (* 6 -> 2 -> 1
@@ -101,7 +101,7 @@ module Test = struct
 
   let%test "lexical successor tree with if" =
     let t = make [data 1 (Instr.Const (Prim_value.of_int 0));
-                  control 2 (Instr.If (None, (0, 1),
+                  control 2 (Instr.If (([], [I32]), (0, 1),
                                        [data 3 (Instr.Const (Prim_value.of_int 0))],
                                        [data 4 (Instr.Const (Prim_value.of_int 0))]));
                   data 5 (Instr.Const (Prim_value.of_int 0))] in
@@ -111,7 +111,7 @@ module Test = struct
 
   let%test "lexical successor tree with if without instructions after branches" =
     let t = make [data 1 (Instr.Const (Prim_value.of_int 0));
-                  control 2 (Instr.If (None, (0, 1),
+                  control 2 (Instr.If (([], [I32]), (0, 1),
                                        [data 3 (Instr.Const (Prim_value.of_int 0))],
                                        [data 4 (Instr.Const (Prim_value.of_int 0))]))] in
     (* What we expect is that a dummy node is added to act as the root *)
@@ -122,7 +122,7 @@ module Test = struct
     let t = make [data 1 (Instr.Const (Prim_value.of_int 0));
                   data 2 (Instr.Const (Prim_value.of_int 0));
                   data 3 (Instr.Compare Relop.{ typ = I32; op = Eq });
-                  control 4 (Instr.If (None, (0, 0),
+                  control 4 (Instr.If (([], []), (0, 0),
                                        [data 5 (Instr.Const (Prim_value.of_int 0));
                                         control 6 Instr.Return],
                                        []));

--- a/lib/helpers.ml
+++ b/lib/helpers.ml
@@ -96,7 +96,6 @@ let pop3 (vstack : 'a list) : ('a * 'a * 'a) =
     | x :: y :: z :: _ -> (x, y, z)
     | _ -> failwith "Invalid vstack when popping 3 values"
 
-
 let error at category msg =
   failwith (Printf.sprintf "Error: %s" (Wasm.Source.string_of_region at ^ ": " ^ category ^ ": " ^ msg))
 
@@ -118,7 +117,9 @@ let input_from get_script run =
 let parse_from_lexbuf_textual name lexbuf run =
   let extract (l : (Wasm.Script.var option * Wasm.Script.definition) list) =
     match l with
-    | (_, { it = Wasm.Script.Textual m; _ }) :: _ -> run m
+    | (_, { it = Wasm.Script.Textual m; _ }) :: _ ->
+      Wasm.Valid.check_module m;
+      run m
     | _ -> failwith "unsupported format" in
     input_from (fun _ ->
         let var_opt, def = Wasm.Parse.parse name lexbuf Wasm.Parse.Module in

--- a/lib/wasm/instr.ml
+++ b/lib/wasm/instr.ml
@@ -81,8 +81,8 @@ module T = struct
   type arity = int * int
   [@@deriving sexp, compare, equal]
 
-  (** The optional type of a block *)
-  type block_type = Type.t option
+  (** The type of a block *)
+  type block_type = Type.t list * Type.t list
   [@@deriving sexp, compare, equal]
 
   (** Data instructions *)
@@ -191,10 +191,13 @@ let data_to_string (instr : data) : string =
      | RefFunc f -> Printf.sprintf "ref.func %ld" f
      | RefIsNull -> "ref.isnull"
 
-let block_type_to_string (bt : block_type) : string = match bt with
-  | None -> ""
-  | Some t ->
-    Printf.sprintf " (result %s)" (Type.to_string t)
+let block_type_to_string (bt : block_type) : string =
+  let to_str (ts : Type.t list) : string = String.concat ~sep:" " (List.map ~f:Type.to_string ts) in
+  match bt with
+  | [], [] -> ""
+  | i, [] -> Printf.sprintf " (param %s)" (to_str i)
+  | [], o -> Printf.sprintf " (result %s)" (to_str o)
+  | i, o -> Printf.sprintf " (param %s) (result %s)" (to_str i) (to_str o)
 
 (** Converts a control instruction to its string representation *)
 let rec control_to_string ?sep:(sep : string = "\n") ?indent:(i : int = 0) ?annot_str:(annot_to_string : 'a -> string = fun _ -> "") (instr : 'a control)  : string =
@@ -313,8 +316,6 @@ let rec of_wasm (m : Wasm.Ast.module_) (new_label : unit -> Label.t) (i : Wasm.A
   | Block (st, instrs) ->
     let block_type = Wasm_helpers.type_of_block m st in
     let (arity_in, arity_out) = Wasm_helpers.arity_of_block m st in
-    assert (arity_in = 0); (* what does it mean to have arity_in > 0? *)
-    assert (arity_out <= 1);
     let label = new_label () in
     let body = seq_of_wasm m new_label instrs in
     control_labelled ~label:label (Block (block_type, (arity_in, arity_out), body))

--- a/test/if-loop.wat
+++ b/test/if-loop.wat
@@ -5,12 +5,14 @@
     (local i32)
     local.get 0
     if
-      block
+      block (result i32)
         local.get 0
       end
-      block
+      block (result i32)
         local.get 0
       end
+      drop
+      drop
     end
     local.get 0)
   ;; every wasm program has to have one table

--- a/test/loop-brif.wat
+++ b/test/loop-brif.wat
@@ -2,7 +2,7 @@
   ;; i32 -> i32 type
   (type (;0;) (func (param i32) (result i32)))
   (func (;0;) (type 0) (param i32) (result i32)
-    (local i32)
+    (local i32 i32 i32)
       loop  ;; label = @2
         local.get 2
         local.get 1

--- a/test/loop.wat
+++ b/test/loop.wat
@@ -2,7 +2,7 @@
   ;; i32 -> i32 type
   (type (;0;) (func (param i32) (result i32)))
   (func (;0;) (type 0) (param i32) (result i32)
-    (local i32)
+    (local i32 i32 i32)
       loop  ;; label = @2
         local.get 2
         local.get 1

--- a/test/simple.wat
+++ b/test/simple.wat
@@ -368,16 +368,16 @@
   (func (;entry-point;) (type 1) (param i32) (result i32) ;; 36
     local.get 0
     call 27)
-  (func (;taint-global-local;) (type 1) (param i32) (result i32) ;; 37
+  (func (;taint-global-local;) (type 0) (param i32) ;; 37
     (local i32)
     global.get 0
     local.tee 1
     global.set 0
     i32.const -1
     local.set 1)
-  (func (;test-loop;) (type 1) (param i32) (result i32) ;; 38
+  (func (;test-loop;) (type 0) (param i32) ;; 38
     ;; loop(pointer, size)
-    (local i32 i32)
+    (local i32 i32 i32)
     local.get 0
     local.set 2 ;; l2 = ptr
     local.get 1

--- a/wassail.opam
+++ b/wassail.opam
@@ -17,7 +17,7 @@ depends: [
   "ppx_inline_test" # MIT
   "ppx_jane" # MIT
   "sexplib" # MIT
-  "wasm" # Apache 2.0
+  "wasm" {= "2.0.1"} # Apache 2.0
   "bisect_ppx" {dev & >= "2.5.0"} # MIT
 ]
 build: [


### PR DESCRIPTION
Modules created with `Wasm_module.of_string` or `of_file` are currently not checked for validity. This means that we can run analyses on invalid modules. We rather prefer to reject modules early and avoid dealing with impossible cases in the analyses.
This changes now enforces modules to be valid upon creation.